### PR TITLE
Support options on set() for easier extending

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,32 +6,35 @@ const icons = require('./tasks/icons');
 const images = require('./tasks/images');
 const javascript = require('./tasks/javascript');
 
-const TASKS = Symbol('tasks');
+const TASKS = Symbol('TASKS');
+const WATCH_TASKS = Symbol('WATCH_TASKS');
+const DEFAULT_TASKS = Symbol('DEFAULT_TASKS');
 
 class GulpRegistryMrHenry {
 	constructor(config = {}) {
 		this[TASKS] = {};
+		this[WATCH_TASKS] = {};
+		this[DEFAULT_TASKS] = [];
 		this.config = config;
 	}
 
 	init(taker) {
-		this.set('css', css(this.config.css));
-		this.set('fonts', fonts(this.config.fonts));
-		this.set('icons', icons(this.config.icons));
-		this.set('images', images(this.config.images));
+		this.set('css', css(this.config.css), { watch: this.config.css.watch });
+		this.set('fonts', fonts(this.config.fonts), { watch: this.config.fonts.src });
+		this.set('icons', icons(this.config.icons), { watch: this.config.icons.src });
+		this.set('images', images(this.config.images), { watch: this.config.images.src });
 
 		const { es6, babel } = javascript(this.config.js);
-		this.set('javascript:es6', es6);
-		this.set('javascript:babel', babel);
-		this.set('javascript', taker.parallel('javascript:es6', 'javascript:babel'));
+		this.set('javascript:es6', es6, { default: false });
+		this.set('javascript:babel', babel, { default: false });
+		this.set('javascript', taker.parallel('javascript:es6', 'javascript:babel'), { watch: this.config.js.watch });
 
-		this.set('default', taker.parallel('css', 'fonts', 'icons', 'images', 'javascript'));
+		this.set('default', taker.parallel(...this[DEFAULT_TASKS]));
 
 		const watch = () => {
-			gulp.watch(this.config.css.watch, this.get('css'));
-			gulp.watch(this.config.fonts.src, this.get('fonts'));
-			gulp.watch(this.config.images.src, this.get('images'));
-			gulp.watch(this.config.js.watch, this.get('javascript'));
+			Object.entries(this[WATCH_TASKS]).forEach(([task, files]) => {
+				gulp.watch(files, this.get(task));
+			});
 		};
 
 		this.set('watch', taker.series('default', watch));
@@ -41,7 +44,19 @@ class GulpRegistryMrHenry {
 		return this[TASKS][task];
 	}
 
-	set(task, fn) {
+	set(task, fn, options = {}) {
+		const defaults = { watch: false, default: true };
+		const settings = Object.assign({}, defaults, options);
+
+		if (!!settings.watch) {
+			const files = settings.watch;
+			this[WATCH_TASKS][task] = files;
+		}
+
+		if (settings.default) {
+			this[DEFAULT_TASKS].push(task);
+		}
+
 		return this[TASKS][task] = fn;
 	}
 


### PR DESCRIPTION
Extending the registry in your own custom gulpfile now is as simple as:

```es6
const gulp = require('gulp');
const MrHenry = require('gulp-registry-mrhenry');
const config = require('./gulp/config');

const tasks = new MrHenry(config);

tasks.set('foo', require('./gulp/tasks/foo')(config.foo), { watch: config.foo.src });

gulp.registry(tasks);
```

This is a proposal to fix #1 